### PR TITLE
Test GPCM and 2PL BISTA transformations

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -45,3 +45,35 @@ jobs:
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true
+
+      - name: Annotate check logs on failure
+        if: failure()
+        shell: Rscript {0}
+        run: |
+          escape_annotation <- function(x) {
+            x <- gsub("%", "%25", x, fixed = TRUE)
+            x <- gsub("\r", "%0D", x, fixed = TRUE)
+            x <- gsub("\n", "%0A", x, fixed = TRUE)
+            x
+          }
+
+          rcheck_dirs <- list.dirs(".", recursive = TRUE, full.names = TRUE)
+          rcheck_dirs <- rcheck_dirs[grepl("\\.Rcheck$", rcheck_dirs)]
+          files <- file.path(rcheck_dirs, "00check.log")
+          test_dirs <- file.path(rcheck_dirs, "tests")
+          files <- c(files, unlist(lapply(test_dirs, list.files,
+            pattern = "\\.Rout(\\.fail)?$", full.names = TRUE
+          )))
+          files <- unique(files[file.exists(files)])
+
+          if (!length(files)) {
+            cat("::warning title=R CMD check logs::No .Rcheck logs found for annotation\n")
+          }
+
+          for (file in files) {
+            lines <- readLines(file, warn = FALSE)
+            tail_lines <- tail(lines, 80)
+            msg <- escape_annotation(paste(tail_lines, collapse = "\n"))
+            title <- escape_annotation(paste("Tail of", file))
+            cat(sprintf("::error title=%s::%s\n", title, msg))
+          }

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -27,7 +27,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,14 @@
 * add tests for equivalence table in partial credit (`simEquiTable()`)
 * bug fix in `simEquiTable()`: read in correct anchor file
 * bugfix in (g)pcm anchoring with tam
+* fix 2PL item parameter transformation to the 62.5% threshold for TAM and mirt
+  parameterizations in `transformToBista()`
+* make 2PL slope detection in `transformToBista()` robust against slope standard
+  error columns
+* add regression tests for TAM vs. mirt 2PL transformations and TAM vs. mirt
+  GPCM Thurstonian thresholds/BISTA item parameters
+* run the TAM vs. mirt PCM Thurstonian threshold test independently from the
+  optional ConQuest executable
 
 # eatModel 0.10.19 [Jun 2026]
 

--- a/R/defineModel_help.R
+++ b/R/defineModel_help.R
@@ -49,23 +49,27 @@ doAufb <- function ( x, argL ) {
 
 identifyConquestFolder <- function () {
   cf <- system.file("extdata", "console_Feb2007.exe", package = "eatModel")
-  if ( nchar(cf)==0) {cf <- system.file("exec", "console_Feb2007.exe", package = "eatModel")} else{return(cf)}
-  if ( nchar(cf)==0) {
-    root <- system.file(package = "eatModel")
-    if ( !file.exists(file.path(root, "exec"))) {dir.create(file.path(root, "exec"))}
-    if ( !file.exists( system.file("exec", "console_Feb2007.exe", package = "eatModel") )) {
-      if ( !file.exists("i:/Methoden/00_conquest_console/console_Feb2007.exe") ) {
-        packageStartupMessage("Cannot find conquest 2007 executable file. Please choose manually.")
-        fname <- file.choose()
-      }  else  {
-        fname <- "i:/Methoden/00_conquest_console/console_Feb2007.exe"
-      }
-      if ( nchar(fname)>0) { foo <- file.copy(from = fname, to = file.path(root, "exec", "console_Feb2007.exe") ) }
-    }
-  } else {
-    return(cf)
-  }
-  return(file.path(root, "exec", "console_Feb2007.exe"))}
+  if ( nchar(cf)>0) {return(cf)}
+
+  cf <- system.file("exec", "console_Feb2007.exe", package = "eatModel")
+  if ( nchar(cf)>0) {return(cf)}
+
+  defaultConquest <- "i:/Methoden/00_conquest_console/console_Feb2007.exe"
+  if ( file.exists(defaultConquest)) {return(defaultConquest)}
+
+  msg <- paste0("Cannot find conquest 2007 executable file. ",
+                "Please provide it via the 'conquest.folder' argument.")
+  if ( !interactive()) {stop(msg, call. = FALSE)}
+
+  packageStartupMessage("Cannot find conquest 2007 executable file. Please choose manually.")
+  fname <- tryCatch(file.choose(), error = function(e) "")
+  if ( nchar(fname)==0) {stop(msg, call. = FALSE)}
+
+  root <- system.file(package = "eatModel")
+  execDir <- file.path(root, "exec")
+  if ( !file.exists(execDir)) {dir.create(execDir)}
+  foo <- file.copy(from = fname, to = file.path(execDir, "console_Feb2007.exe"))
+  return(file.path(execDir, "console_Feb2007.exe"))}
 
 ### ----------------------------------------------------------------------------
 

--- a/R/getTrafo.r
+++ b/R/getTrafo.r
@@ -1,7 +1,10 @@
 getTrafo <- function(dataBase = "I:/Methoden/10_sonstige Materialien/trafo.rda", mode=c("paper","pc"), grade=c("primary", "secondary"), subject = c("math", "deu", "eng", "frz", "bio", "che", "phy"),
             domain = c("all", "GL", "ZO", "RF", "MS", "GM", "DHW", "ZA", "ME", "FZ", "DZ", "lesen", "hoeren", "ortho", "sg", "CE", "CF", "PE", "PF", "BE", "BF"),
             study = c("bt", "vera")) {
-    if(inherits(dataBase, "character")) {load(dataBase)} else {trafo <- dataBase}
+    if(inherits(dataBase, "character")) {
+       if(!file.exists(dataBase)) {stop(paste0("Cannot find transformation database '", dataBase, "'."), call. = FALSE)}
+       load(dataBase)
+    } else {trafo <- dataBase}
     mode   <- match.arg(arg=mode, choices=eval(formals(getTrafo)[["mode"]]))
     grade  <- match.arg(arg=grade, choices=eval(formals(getTrafo)[["grade"]]))
     subject<- match.arg(arg=subject, choices=eval(formals(getTrafo)[["subject"]]), several.ok = TRUE)

--- a/R/transformToBista.R
+++ b/R/transformToBista.R
@@ -91,7 +91,8 @@ transformToBista <- function(equatingList, refPop, cuts, weights = NULL,
                                      }
                                 }
                                 if(!isPCM) {                                    ### transformation auf .625 fuer dichotom: andere Transformation fuer 2pl dichotom als fuer 1pl dichotom
-                                   slp1<- grep("slope", colnames(itFrame), value=TRUE, ignore.case=TRUE) 
+                                   slp1<- grep("slope", colnames(itFrame), value=TRUE, ignore.case=TRUE)
+                                   slp1<- slp1[!grepl("(^se|_se$|\\.se$|se$|stderr|std\\.err|error)", slp1, ignore.case=TRUE)]
                                    slp2<- grep("est", colnames(itFrame), value=TRUE, ignore.case=TRUE) 
                                    if(length(slp1) < 2 || length(slp2) ==0) {   ### wenn es nur eine spalte mit "slope" im Namen gibt, ist das die estimator-spalte,
                                       slp <- slp1                               ### selbst wenn sie nicht mit "est" benannt ist. Gibt es zusaetzlich noch einen
@@ -105,7 +106,20 @@ transformToBista <- function(equatingList, refPop, cuts, weights = NULL,
                                       if(any(itFrame[,slp] < 0)) {
                                          warning("The slope parameters for some items are less than 0. These item parameters cannot be meaningfully transformed into the educational standards metric.")
                                       }                                         ### untere Zeile: Variante fuer 2pl entsprechend Karolines AI-Agent (Mail Karoline, 11.06.2026, 9.24 Uhr, bzw. "https://github.com/weirichs/eatModel/issues/34#issuecomment-4829725821")
-                                      if(attr(equatingList[["results"]], "runModelAttributes")[["software"]] == "tam") {
+                                      software <- attr(equatingList[["results"]], "runModelAttributes")[["software"]]
+                                      if(is.null(software) || length(software) == 0) {
+                                         if(exists("resMD") && "source" %in% colnames(resMD)) {
+                                            software <- unique(na.omit(resMD[,"source"]))
+                                         } else {
+                                            if("source" %in% colnames(equatingList[["results"]])) {
+                                               software <- unique(na.omit(equatingList[["results"]][,"source"]))
+                                            }
+                                         }
+                                      }
+                                      if(length(software) != 1) {
+                                         stop("Cannot uniquely identify estimation software for 2PL item parameter transformation.")
+                                      }
+                                      if(software == "tam") {
                                          itFrame[,"estTransf625"]<- (itFrame[,"estTransf"] + log(0.625/(1-0.625))) / itFrame[,slp]
                                       } else {                                  ### obere Zeile: tam; untere Zeile: mirt
                                          itFrame[,"estTransf625"]<- itFrame[,"estTransf"] + log(0.625/(1-0.625)) / itFrame[,slp]

--- a/man/defineModel.Rd
+++ b/man/defineModel.Rd
@@ -458,6 +458,10 @@ Desired number of plausible values.
 Sebastian Weirich
 }
 \examples{
+if (interactive()) {
+# These examples run full TAM/mirt/ConQuest analyses and are intended for
+# interactive exploration. The corresponding smoke and regression coverage lives
+# in tests/testthat.
 ################################################################################
 ###               Preparation: necessary for all examples                    ###
 ################################################################################
@@ -1674,6 +1678,7 @@ trnsf<- transformToBista(equatingList=eq, refPop= data.frame(domain="Dim1",
         m = mSDR[which(mSDR[,"parameter"] == "mean"),"est"],
         sd = mSDR[which(mSDR[,"parameter"] == "sd"),"est"]),
         cuts = list(Dim1 = list(values = c(400,600))), vera=FALSE)
+}
 }
 
 

--- a/man/defineModel.Rd
+++ b/man/defineModel.Rd
@@ -478,7 +478,7 @@ qMat <- data.frame ( qMat[,"item", drop=FALSE], model.matrix(~domain-1, data = q
 
 # Example 1: define and run a unidimensional Rasch model for the 2010 cohort
 # with all variables from booklet 02 (this booklet contains  reading and listening
-# items together). For the estimation, Conquest is used.
+# items together). For the estimation, TAM is used.
 # Since the wide-format dataset generated here will be used in later analyses,
 # several covariates - such as gender and SES - are generated at the same time.
 # These variables are not yet used in this example.
@@ -486,7 +486,7 @@ datW <- subset(trends, booklet == "Bo02" & year == 2010) |>
         reshape2::dcast(idstud+language+sex+ses+country~item, value.var = "value")
 
 # defining the unidimensional model: specifying q matrix is not necessary
-mod1 <- defineModel(dat=datW, items= -c(1:5), id="idstud", analysis.name = "unidim", dir = tempdir())
+mod1 <- defineModel(dat=datW, items= -c(1:5), id="idstud", analysis.name = "unidim", dir = tempdir(), software = "tam")
 
 # run the model
 run1 <- runModel(mod1)
@@ -514,7 +514,7 @@ datW[,"sexNum"] <- car::recode ( datW[,"sex"] , "'male'=0; 'female'=1", as.facto
 # means: Everything except column 1 to 5 are item columns
 items<- grep("^T[[:digit:]]{2}", colnames(datW))
 mod1a<- defineModel(dat=datW, items= items, id="idstud", DIF.var = "sexNum",
-        analysis.name = "unidimDIF", dir = tempdir())
+        analysis.name = "unidimDIF", dir = tempdir(), software = "tam")
 
 # run the model
 run1a<- runModel(mod1a)
@@ -527,6 +527,7 @@ res1a<- getResults(run1a)
 ### Example 1b: Rasch Model with DIF variable in customized model statement  ###
 ################################################################################
 
+\dontrun{
 # builing on example 1a, the DIF variable should be used without interaction term
 # and without eliminating items which do not vary within DIF groups. We need the
 # 'sexNum' variable which was defined previously
@@ -543,6 +544,7 @@ res1b<- getResults(run1b)
 
 # item parameter
 it1b <- itemFromRes(res1b)
+}
 
 
 ################################################################################
@@ -561,7 +563,7 @@ aPar <- itemFromRes(res1)[,c("item", "est")]
 # (This behavior is equivalent as in lm() for example.)
 mod2a<- defineModel(dat=datW, items= grep("^T[[:digit:]]{2}", colnames(datW)),
         id="idstud", analysis.name = "twodim", HG.var = c("language","sex", "ses"),
-        qMatrix = qMat, anchor = aPar, n.plausible = 20,dir = tempdir())
+        qMatrix = qMat, anchor = aPar, n.plausible = 20,dir = tempdir(), software = "tam")
 
 # run the model
 run2a<- runModel(mod2a)
@@ -578,7 +580,7 @@ res2a<- getResults(run2a)
 # without anchoring. Defining the model: specifying q matrix now is necessary.
 mod2b<- defineModel(dat=datW, items= grep("^T[[:digit:]]{2}", colnames(datW)),
         id="idstud", analysis.name = "twodim2", qMatrix = qMat,
-        n.plausible = 20, dir = tempdir())
+        n.plausible = 20, dir = tempdir(), software = "tam")
 
 # run the model
 run2b <- runModel(mod2b)
@@ -1348,6 +1350,7 @@ tf4  <- transformToBista(equatingList=eq4, refPop=refP, cuts=cuts, vera = FALSE)
 ### Example 8.1: same like example 8 (anchored 1pl PCM), now using Conquest  ###
 ################################################################################
 
+\dontrun{
 # load partial credit long format data
 data(reading)
 
@@ -1423,6 +1426,7 @@ eq4  <- equat1pl(results = res3B)                                               
 refP <- data.frame(domain = "Dim1", m = 0.0389, sd = 1.07108, stringsAsFactors = FALSE)
 cuts <- list ( Dim1 = list(values = 390+0:3*75))
 tf4  <- transformToBista(equatingList=eq4, refPop=refP, cuts=cuts, vera = FALSE)
+}
 
 
 ################################################################################
@@ -1616,12 +1620,14 @@ defT<- defineModel(dat = dw, items = -c(1:2), DIF.var="sex", DIF.free = "D204063
 runT<- runModel(defT)
 resT<- getResults(runT)
 
+\dontrun{
 # the same model in conquest (recommended)
 defC<- defineModel(dat = dw, items = -c(1:2), model.statement = "item+item*step - sex + item*sex", DIF.var="sex", id = "idstud", analysis.name = "dif_pcm", dir=tempdir())
 runC<- runModel(defC, wait=TRUE)
 resC<- getResults(runC)
 it  <- itemFromRes(resC)
 shw <- get.shw(file.path(tempdir(), "dif_pcm.shw"), dif.term = "item*sex")
+}
 
 
 ################################################################################

--- a/man/defineModel.Rd
+++ b/man/defineModel.Rd
@@ -458,10 +458,9 @@ Desired number of plausible values.
 Sebastian Weirich
 }
 \examples{
-if (interactive()) {
-# These examples run full TAM/mirt/ConQuest analyses and are intended for
-# interactive exploration. The corresponding smoke and regression coverage lives
-# in tests/testthat.
+\dontrun{
+# These examples run full TAM/mirt/ConQuest analyses. R CMD check skips them by
+# default, but they can still be run locally via run_dontrun = TRUE.
 ################################################################################
 ###               Preparation: necessary for all examples                    ###
 ################################################################################
@@ -490,7 +489,7 @@ datW <- subset(trends, booklet == "Bo02" & year == 2010) |>
         reshape2::dcast(idstud+language+sex+ses+country~item, value.var = "value")
 
 # defining the unidimensional model: specifying q matrix is not necessary
-mod1 <- defineModel(dat=datW, items= -c(1:5), id="idstud", analysis.name = "unidim", dir = tempdir(), software = "tam")
+mod1 <- defineModel(dat=datW, items= -c(1:5), id="idstud", analysis.name = "unidim", software = "tam")
 
 # run the model
 run1 <- runModel(mod1)
@@ -518,7 +517,7 @@ datW[,"sexNum"] <- car::recode ( datW[,"sex"] , "'male'=0; 'female'=1", as.facto
 # means: Everything except column 1 to 5 are item columns
 items<- grep("^T[[:digit:]]{2}", colnames(datW))
 mod1a<- defineModel(dat=datW, items= items, id="idstud", DIF.var = "sexNum",
-        analysis.name = "unidimDIF", dir = tempdir(), software = "tam")
+        analysis.name = "unidimDIF", software = "tam")
 
 # run the model
 run1a<- runModel(mod1a)
@@ -531,7 +530,6 @@ res1a<- getResults(run1a)
 ### Example 1b: Rasch Model with DIF variable in customized model statement  ###
 ################################################################################
 
-\dontrun{
 # builing on example 1a, the DIF variable should be used without interaction term
 # and without eliminating items which do not vary within DIF groups. We need the
 # 'sexNum' variable which was defined previously
@@ -548,7 +546,6 @@ res1b<- getResults(run1b)
 
 # item parameter
 it1b <- itemFromRes(res1b)
-}
 
 
 ################################################################################
@@ -567,7 +564,7 @@ aPar <- itemFromRes(res1)[,c("item", "est")]
 # (This behavior is equivalent as in lm() for example.)
 mod2a<- defineModel(dat=datW, items= grep("^T[[:digit:]]{2}", colnames(datW)),
         id="idstud", analysis.name = "twodim", HG.var = c("language","sex", "ses"),
-        qMatrix = qMat, anchor = aPar, n.plausible = 20,dir = tempdir(), software = "tam")
+        qMatrix = qMat, anchor = aPar, n.plausible = 20, software = "tam")
 
 # run the model
 run2a<- runModel(mod2a)
@@ -584,7 +581,7 @@ res2a<- getResults(run2a)
 # without anchoring. Defining the model: specifying q matrix now is necessary.
 mod2b<- defineModel(dat=datW, items= grep("^T[[:digit:]]{2}", colnames(datW)),
         id="idstud", analysis.name = "twodim2", qMatrix = qMat,
-        n.plausible = 20, dir = tempdir(), software = "tam")
+        n.plausible = 20, software = "tam")
 
 # run the model
 run2b <- runModel(mod2b)
@@ -1354,7 +1351,6 @@ tf4  <- transformToBista(equatingList=eq4, refPop=refP, cuts=cuts, vera = FALSE)
 ### Example 8.1: same like example 8 (anchored 1pl PCM), now using Conquest  ###
 ################################################################################
 
-\dontrun{
 # load partial credit long format data
 data(reading)
 
@@ -1430,7 +1426,6 @@ eq4  <- equat1pl(results = res3B)                                               
 refP <- data.frame(domain = "Dim1", m = 0.0389, sd = 1.07108, stringsAsFactors = FALSE)
 cuts <- list ( Dim1 = list(values = 390+0:3*75))
 tf4  <- transformToBista(equatingList=eq4, refPop=refP, cuts=cuts, vera = FALSE)
-}
 
 
 ################################################################################
@@ -1624,14 +1619,12 @@ defT<- defineModel(dat = dw, items = -c(1:2), DIF.var="sex", DIF.free = "D204063
 runT<- runModel(defT)
 resT<- getResults(runT)
 
-\dontrun{
 # the same model in conquest (recommended)
 defC<- defineModel(dat = dw, items = -c(1:2), model.statement = "item+item*step - sex + item*sex", DIF.var="sex", id = "idstud", analysis.name = "dif_pcm", dir=tempdir())
 runC<- runModel(defC, wait=TRUE)
 resC<- getResults(runC)
 it  <- itemFromRes(resC)
 shw <- get.shw(file.path(tempdir(), "dif_pcm.shw"), dif.term = "item*sex")
-}
 
 
 ################################################################################

--- a/man/eapFromRes.Rd
+++ b/man/eapFromRes.Rd
@@ -24,6 +24,8 @@ group name, EAP and the corresponding standard error.
 \examples{
 ### read exemplary results object
 file <- system.file("extdata", "results.rda", package = "eatModel")
+if (nzchar(file)) {
 load(file)
 eap  <- eapFromRes(res)
+}
 }

--- a/man/eapRelFromRes.Rd
+++ b/man/eapRelFromRes.Rd
@@ -19,6 +19,8 @@ EAP reliability.
 \examples{
 ### read exemplary results object
 file <- system.file("extdata", "results.rda", package = "eatModel")
+if (nzchar(file)) {
 load(file)
 eapRel <- eapRelFromRes(res)
+}
 }

--- a/man/get.dsc.Rd
+++ b/man/get.dsc.Rd
@@ -35,7 +35,11 @@ Version 2.0. Generalised Item Response Modeling Software.} Camberwell, Victoria:
 }
 \examples{
 file <- system.file("extdata", "twodim_pvl.dsc", package = "eatModel")
+if (nzchar(file)) {
 dscPV<- get.dsc(file)
+}
 file <- system.file("extdata", "twodim_wle.dsc", package = "eatModel")
+if (nzchar(file)) {
 dscWL<- get.dsc(file)
+}
 }

--- a/man/get.equ.Rd
+++ b/man/get.equ.Rd
@@ -32,5 +32,7 @@ Version 2.0. Generalised Item Response Modeling Software.} Camberwell, Victoria:
 }
 \examples{
 file <- system.file("extdata", "twodim.equ", package = "eatModel")
+if (nzchar(file)) {
 equ  <- get.equ(file)
+}
 }

--- a/man/get.itn.Rd
+++ b/man/get.itn.Rd
@@ -48,5 +48,7 @@ Version 2.0. Generalised Item Response Modeling Software.} Camberwell, Victoria:
 }
 \examples{
 file <- system.file("extdata", "twodim.itn", package = "eatModel")
+if (nzchar(file)) {
 itn  <- get.itn(file)
+}
 }

--- a/man/get.plausible.Rd
+++ b/man/get.plausible.Rd
@@ -39,5 +39,7 @@ For example, se.eap_Dim.2 refers to the standard error of the EAP estimate of th
 }
 \examples{
 file <- system.file("extdata", "twodim.pvl", package = "eatModel")
+if (nzchar(file)) {
 pv   <- get.plausible(file)
+}
 }

--- a/man/get.prm.Rd
+++ b/man/get.prm.Rd
@@ -26,5 +26,7 @@ A data frame with three columns:
 }
 \examples{
 file <- system.file("extdata", "twodim.prm", package = "eatModel")
+if (nzchar(file)) {
 prm  <- get.prm(file)
+}
 }

--- a/man/get.shw.Rd
+++ b/man/get.shw.Rd
@@ -83,5 +83,7 @@ fitted.
 }
 \examples{
 file <- system.file("extdata", "twodim.shw", package = "eatModel")
+if (nzchar(file)) {
 shw  <- get.shw(file)
+}
 }

--- a/man/get.wle.Rd
+++ b/man/get.wle.Rd
@@ -35,5 +35,7 @@ Version 2.0. Generalised Item Response Modeling Software.} Camberwell, Victoria:
 }
 \examples{
 file <- system.file("extdata", "twodim.wle", package = "eatModel")
+if (nzchar(file)) {
 wle  <- get.wle(file)
+}
 }

--- a/man/getTrafo.Rd
+++ b/man/getTrafo.Rd
@@ -94,6 +94,7 @@ A list with four objects.
 \item{info}{Character string with short information about refrence population}
 }
 \examples{
+\dontrun{
 # transformation rules for all domains subject deutsch, primary level
 primDeu <- getTrafo(mode="paper", grade="primary", subject = "deu",
            domain = "all", study = "vera")
@@ -101,6 +102,7 @@ primDeu <- getTrafo(mode="paper", grade="primary", subject = "deu",
 # transformation rules for all science domains
 secScien<- getTrafo(mode="paper", grade="secondary", subject = c("bio", "che", "phy"),
            domain = "all", study = "bt")
+}
 }
 \references{
 

--- a/man/getTrafo.Rd
+++ b/man/getTrafo.Rd
@@ -94,16 +94,14 @@ A list with four objects.
 \item{info}{Character string with short information about refrence population}
 }
 \examples{
-\dontrun{
+trafoDB <- formals(getTrafo)$dataBase
+if (file.exists(trafoDB)) {
 # transformation rules for all domains subject deutsch, primary level
-primDeu <- getTrafo(mode="paper", grade="primary", subject = "deu",
+primDeu <- getTrafo(dataBase = trafoDB, mode="paper", grade="primary", subject = "deu",
            domain = "all", study = "vera")
 
 # transformation rules for all science domains
-secScien<- getTrafo(mode="paper", grade="secondary", subject = c("bio", "che", "phy"),
+secScien<- getTrafo(dataBase = trafoDB, mode="paper", grade="secondary", subject = c("bio", "che", "phy"),
            domain = "all", study = "bt")
 }
-}
-\references{
-
 }

--- a/man/itemFromRes.Rd
+++ b/man/itemFromRes.Rd
@@ -23,6 +23,8 @@ parameters, standard errors, infit and outfit.
 \examples{
 ### read exemplary results object
 file <- system.file("extdata", "results.rda", package = "eatModel")
+if (nzchar(file)) {
 load(file)
 items<- itemFromRes(res)
+}
 }

--- a/man/multiEquatError.Rd
+++ b/man/multiEquatError.Rd
@@ -37,9 +37,9 @@ Monseur, C., & Berezner, A. (2007). The Computation of Equating Errors in Intern
 in Education. \emph{Journal of Applied Measurement 8}(3): 323-335.
 }
 \examples{
-if (interactive()) {
-# These examples calibrate several TAM models and are intended for interactive
-# exploration. The package tests cover the linking-error calculations directly.
+\dontrun{
+# These examples calibrate several TAM models. R CMD check skips them by default,
+# but they can still be run locally via run_dontrun = TRUE.
 data(trends)
 
 ################################################################################

--- a/man/multiEquatError.Rd
+++ b/man/multiEquatError.Rd
@@ -37,6 +37,9 @@ Monseur, C., & Berezner, A. (2007). The Computation of Equating Errors in Intern
 in Education. \emph{Journal of Applied Measurement 8}(3): 323-335.
 }
 \examples{
+if (interactive()) {
+# These examples calibrate several TAM models and are intended for interactive
+# exploration. The package tests cover the linking-error calculations directly.
 data(trends)
 
 ################################################################################
@@ -126,4 +129,5 @@ eq.1_2 <- equat1pl(e1, e2,difBound = 0.64, iterativ = TRUE)
 eq.2_3 <- equat1pl(e2, e3,difBound = 0.64, iterativ = TRUE)
 eq.1_3 <- equat1pl(e1, e3,difBound = 0.64, iterativ = TRUE)
 multiEquatError(eq.1_2, eq.2_3, eq.1_3)
+}
 }

--- a/man/plotICC.Rd
+++ b/man/plotICC.Rd
@@ -47,6 +47,9 @@ behavior of the S3 plot method of \code{TAM}, use the value 7.
 Sebastian Weirich
 }
 \examples{
+if (interactive()) {
+# This example estimates a TAM model before plotting and is intended for
+# interactive exploration.
 data(trends)
 # choose only 2010
 dat <- trends[which(trends[,"year"] == 2010),]
@@ -65,6 +68,7 @@ run1 <- runModel(mod1)
 # get the results
 res1 <- getResults(run1)
 
-# plot for one item 
+# plot for one item
 plotICC  ( resultsObj = res1, defineModelObj = mod1, items = "T04_04")
+}
 }

--- a/man/plotICC.Rd
+++ b/man/plotICC.Rd
@@ -1,6 +1,6 @@
 \name{plotICC}
 \alias{plotICC}
-\title{Plots item characteristic curves.}
+\title{Plots item characteristic curves}
 \description{Function provides item characteristic plots for each item.}
 \usage{plotICC  ( resultsObj, defineModelObj, runModelObj = NULL, items = NULL,
        personPar = c("WLE", "EAP", "PV"), personsPerGroup = 30, pdfFolder = NULL,
@@ -47,9 +47,9 @@ behavior of the S3 plot method of \code{TAM}, use the value 7.
 Sebastian Weirich
 }
 \examples{
-if (interactive()) {
-# This example estimates a TAM model before plotting and is intended for
-# interactive exploration.
+\dontrun{
+# This example estimates a TAM model before plotting. R CMD check skips it by
+# default, but it can still be run locally via run_dontrun = TRUE.
 data(trends)
 # choose only 2010
 dat <- trends[which(trends[,"year"] == 2010),]

--- a/man/pvFromRes.Rd
+++ b/man/pvFromRes.Rd
@@ -28,6 +28,8 @@ model dimension(s), student ID, and several columns with the plausible values.
 \examples{
 ### read exemplary results object
 file <- system.file("extdata", "results.rda", package = "eatModel")
+if (nzchar(file)) {
 load(file)
 pv   <- pvFromRes(res)
+}
 }

--- a/man/q3FromRes.Rd
+++ b/man/q3FromRes.Rd
@@ -25,6 +25,8 @@ A list of data frames, one data.frame per model.
 \examples{
 ### read exemplary results object
 file <- system.file("extdata", "results.rda", package = "eatModel")
+if (nzchar(file)) {
 load(file)
 q3   <- q3FromRes(res)
+}
 }

--- a/man/regcoefFromRes.Rd
+++ b/man/regcoefFromRes.Rd
@@ -23,6 +23,8 @@ the corresponding regression coefficients.
 \examples{
 ### read exemplary results object
 file <- system.file("extdata", "results.rda", package = "eatModel")
+if (nzchar(file)) {
 load(file)
 regs <- regcoefFromRes(res)
+}
 }

--- a/man/simEquiTable.Rd
+++ b/man/simEquiTable.Rd
@@ -64,6 +64,7 @@ Johannes Schult, Sebastian Weirich
 ### Example 1: equivalence table for Rasch models
 # read anchor parameter
 file <- system.file("extdata", "results.rda", package = "eatModel")
+if (nzchar(file)) {
 load(file)
 
 # use domain 'reading'
@@ -74,6 +75,7 @@ cuts   <- list ( values = 390+0:3*75, labels = c("I", "II", "III", "IV", "V") )
 
 # create the equivalence table
 ret <- simEquiTable( anchor = prm[,c("item", "est")], cutScores = cuts , mRef = 0.039, sdRef = 1.071)
+}
 
 ### Example 2: equivalence table for partial credit model
 # load partial credit data

--- a/man/simEquiTable.Rd
+++ b/man/simEquiTable.Rd
@@ -78,9 +78,9 @@ ret <- simEquiTable( anchor = prm[,c("item", "est")], cutScores = cuts , mRef = 
 }
 
 ### Example 2: equivalence table for partial credit model
-if (interactive()) {
-# This example estimates a partial-credit model and is intended for interactive
-# exploration.
+\dontrun{
+# This example estimates a partial-credit model. R CMD check skips it by default,
+# but it can still be run locally via run_dontrun = TRUE.
 # load partial credit data
 data(reading)
 

--- a/man/simEquiTable.Rd
+++ b/man/simEquiTable.Rd
@@ -78,6 +78,9 @@ ret <- simEquiTable( anchor = prm[,c("item", "est")], cutScores = cuts , mRef = 
 }
 
 ### Example 2: equivalence table for partial credit model
+if (interactive()) {
+# This example estimates a partial-credit model and is intended for interactive
+# exploration.
 # load partial credit data
 data(reading)
 
@@ -93,4 +96,5 @@ it  <- itemFromRes(resT)
 # create equivalence table with arbitrary cuts and reference values
 ret2<- simEquiTable( anchor = it, item = "item", cat="category", value = "est",
        cutScores = list ( values = c(400, 600)), mRef = 0.047, sdRef = 1.181)
+}
 }

--- a/man/wleFromRes.Rd
+++ b/man/wleFromRes.Rd
@@ -28,6 +28,8 @@ Sebastian Weirich
 \examples{
 ### read exemplary results object
 file <- system.file("extdata", "results.rda", package = "eatModel")
+if (nzchar(file)) {
 load(file)
 wles <- wleFromRes(res)
+}
 }

--- a/man/wleRelFromRes.Rd
+++ b/man/wleRelFromRes.Rd
@@ -19,6 +19,8 @@ the corresponding WLE reliability.
 \examples{
 ### read exemplary results object
 file <- system.file("extdata", "results.rda", package = "eatModel")
+if (nzchar(file)) {
 load(file)
 wleRel <- wleRelFromRes(res)
+}
 }

--- a/tests/testthat/test_defineModel.R
+++ b/tests/testthat/test_defineModel.R
@@ -1,10 +1,11 @@
 cf <- system.file("extdata", "console_Feb2007.exe", package = "eatModel")
+hasConquest <- nchar(cf)>0 && file.exists(cf)
 path <- getwd() # defineMOdel aender setwd(), deshalb muss das hier wieder zurueckgesetzt werden
 
 #load(pl2w("c:/diskdrv/Winword/Psycho/IQB/Dropbox/R/eat/eatModel/tests/testthat/vera_dat.rda"))
 load(test_path("vera_dat.rda"))
 
-if(isTRUE(file.exists(cf))){
+if(hasConquest){
     test_that("defineModel works for DIF", {
         itemIndex <- grep("^CE|^EC|^CO|^OC", colnames(findat))
         itemNames <- colnames(findat)[itemIndex]
@@ -21,14 +22,14 @@ if(isTRUE(file.exists(cf))){
 ###
 load(system.file("extdata", "pcm", "input.rda", package = "eatModel"))
 
-if(isTRUE(file.exists(cf))){
+if(hasConquest){
     test_that("defineModel works for three-dimensional model", {
         define3d <- suppressWarnings(defineModel(dat = datAufbereitet, items = qmatrix[,"item_neu"], id = "Pseudonyme",HG.var = "Note.y", model.statement = "item + item*step", nodes = 50,
                     qMatrix = qmatrix[,c("item_neu", "dimensionIn", "dimensionSp","dimensionSt")],  dir = tempdir(), analysis.name = "pcm1_3d"))
     })
 }
 file.zip <- system.file("extdata", "pcm", "results.zip", package = "eatModel")
-zip::unzip(zipfile = file.zip, exdir=tempdir())
+utils::unzip(zipfile = file.zip, exdir=tempdir())
 
 test_that("importing results works for three-dimensional model", {
     run3d[["dir"]] <- tempdir()
@@ -40,7 +41,7 @@ test_that("importing results works for three-dimensional model", {
 setwd(path)
 load(test_path("japan.rda"))
 
-if(isTRUE(file.exists(cf))){
+if(hasConquest){
     test_that("temporal item renaming works", {
         defDif3 <- suppressWarnings(defineModel(dat = jpn, id = "person", items = grep("^M1", colnames(jpn), value=TRUE), software="conquest", DIF.var = "SEX", dir = tempdir(), analysis.name = "DIF"))
         runDif3 <- runModel(defDif3)
@@ -52,7 +53,7 @@ if(isTRUE(file.exists(cf))){
 setwd(path)
 load(test_path("df_example2.rda"))
 
-if(isTRUE(file.exists(cf))){
+if(hasConquest){
     test_that("defineModel works for achoring", {
         def <- suppressWarnings(defineModel(dat = datSel, items = intersect(qmat[,"item"],colnames(datSel)), compute.fit = FALSE, id = "IDSTUD", remove.constant.items = TRUE,method = "montecarlo", nodes = 8000,weight.var = "totwgt_NAW",
             qMatrix = qmat[,c("item", "splitbio_knowledge", "splitbio_procedural")], anchor = anchor[["itempars"]][,c("item", "estTransf")], HG.var = c("designDichotom", grep("^PC", colnames(datSel),value=TRUE)), analysis.name = "withWeights", n.plausible = 15, dir = tempdir()))
@@ -62,7 +63,7 @@ if(isTRUE(file.exists(cf))){
 # single
    data(trends)
 
-if(isTRUE(file.exists(cf))){
+if(hasConquest){
     test_that("item renaming (back and forward) works for single model", {
     dat  <- subset(trends, year == 2010 & booklet == "Bo01" & domain == "listening")
     datW <- reshape2::dcast(dat,idstud+sex~item, value.var = "value")
@@ -76,7 +77,7 @@ if(isTRUE(file.exists(cf))){
     })
 }
 # multiple
-if(isTRUE(file.exists(cf))){
+if(hasConquest){
     test_that("item renaming (back and forward) works for multiple models", {
     dat  <- subset(trends, year == 2010 & booklet == "Bo01")
     datW <- reshape2::dcast(dat,idstud+sex~item, value.var = "value")

--- a/tests/testthat/test_simEquiTable_polytom.r
+++ b/tests/testthat/test_simEquiTable_polytom.r
@@ -57,8 +57,10 @@ comp<- merge(wle3[,c("NitemsSolved", "wle_est")], eqt2[,c("NitemsSolved", "wle_e
 test_that("comparison object has exactly 15 rows", {
   expect_true(nrow(comp) == 15)
 })
-test_that("both wle columns are equivaent", {
-  expect_true(all(comp[,"wle_est.x"] == comp[,"wle_est.y"]))
+test_that("both wle columns are equivalent", {
+  # TAM's WLE estimates can differ by tiny platform-specific floating point
+  # amounts, especially on macOS/ARM, so compare numerically rather than by ==.
+  expect_equal(comp[,"wle_est.x"], comp[,"wle_est.y"], tolerance = 1e-6)
 })
 
 # creating the same table, now using the function simEquiTable()
@@ -69,7 +71,8 @@ comp <- merge(eqt4[["complete"]][,c("score", "est")], wle3[,c("NitemsSolved", "w
 test_that("there are exactly as many unique WLEs as there are overall item categories", {
   expect_true(nrow(comp) == (nrow(it) + 1))
 })
-test_that("both wle columns are equivaent", {
-  expect_true(all(comp[,"est"] == comp[,"wle_est"]))
+test_that("both wle columns are equivalent", {
+  # Same equivalence check as above, with numerical tolerance for platform drift.
+  expect_equal(comp[,"est"], comp[,"wle_est"], tolerance = 1e-6)
 })
 

--- a/tests/testthat/test_thurstone_thresholds.R
+++ b/tests/testthat/test_thurstone_thresholds.R
@@ -6,6 +6,7 @@ expect_all_abs_lt <- function(x, tolerance) {
 data(reading)
 #sysInfo  <- Sys.info()
 cf <- system.file("extdata", "console_Feb2007.exe", package = "eatModel")
+hasConquest <- nchar(cf)>0 && file.exists(cf)
 
 # tam: To speed up the process, the tests will be administered only for Test
 # Booklet 8. This booklet contains questions with some partial credit items.
@@ -41,7 +42,7 @@ test_that("PCM Thurstonian thresholds are comparable for TAM and mirt", {
 })
 
 # conquest
-if(isTRUE(file.exists(cf))){
+if(hasConquest){
     defC<- suppressWarnings(defineModel(dat = dw, items = -1, id = "idstud", model.statement = "item+item*step", nodes = 21, analysis.name = "pcm_conquest", dir=tempdir()))
     runC<- runModel(defC)
     resC<- suppressWarnings(getResults(runC))

--- a/tests/testthat/test_thurstone_thresholds.R
+++ b/tests/testthat/test_thurstone_thresholds.R
@@ -1,3 +1,7 @@
+expect_all_abs_lt <- function(x, tolerance) {
+    expect_true(all(abs(x) < tolerance), info = paste("Maximum absolute difference:", max(abs(x), na.rm = TRUE)))
+}
+
 ### only 1pl Rasch and partial credit
 data(reading)
 #sysInfo  <- Sys.info()
@@ -18,26 +22,29 @@ defM<- suppressWarnings(defineModel(dat = dw, items = -1, id = "idstud",  irtmod
 runM<- runModel(defM)
 resM<- suppressWarnings(getResults(runM))
 
+# Unfortunately, the parameters are not exactly the same, but only approximately so.
+# This is inherent in probabilistic estimation. The test is therefore also performed
+# only on the basis of approximate equality.
+itT <- itemFromRes(resT)
+itM <- itemFromRes(resM)
+merge1 <- eatTools::mergeAttr(itT[,c("item", "category", "est", "thurstone")], itM[,c("item", "category", "est", "thurstone")], by=c("item", "category"), setAttr=FALSE, all=TRUE, xName="tam", yName = "mirt", suffixes = c("_tam", "_mirt"))
+merge1[,"diff_est"] <- merge1[,"est_tam"] - merge1[,"est_mirt"]
+merge1[,"diff_thurs"] <- merge1[,"thurstone_tam"] - merge1[,"thurstone_mirt"]
+ind <- which(abs(merge1[,"diff_est"]) < 0.01)
+
+# tam.threshold() is used for TAM, while mirt thresholds are computed in eatModel.
+# For PCM, both paths should lead to nearly identical 62.5% Thurstonian thresholds.
+test_that("PCM Thurstonian thresholds are comparable for TAM and mirt", {
+   expect_gt(nrow(merge1), 0)
+   expect_gt(length(ind), 0)
+   expect_all_abs_lt(merge1[ind,"diff_thurs"], tolerance = 0.02)
+})
+
 # conquest
 if(isTRUE(file.exists(cf))){
     defC<- suppressWarnings(defineModel(dat = dw, items = -1, id = "idstud", model.statement = "item+item*step", nodes = 21, analysis.name = "pcm_conquest", dir=tempdir()))
     runC<- runModel(defC)
     resC<- suppressWarnings(getResults(runC))
-
-    # Unfortunately, the parameters are not exactly the same, but only approximately so.
-    # This is inherent in probabilistic estimation. The test is therefore also performed
-    # only on the basis of approximate equality.
-    itT <- itemFromRes(resT)
-    itM <- itemFromRes(resM)
-    merge1 <- eatTools::mergeAttr(itT[,c("item", "category", "est", "thurstone")], itM[,c("item", "category", "est", "thurstone")], by=c("item", "category"), setAttr=FALSE, all=TRUE, xName="tam", yName = "mirt", suffixes = c("_tam", "_mirt"))
-    merge1[,"diff_est"] <- merge1[,"est_tam"] - merge1[,"est_mirt"]
-    merge1[,"diff_thurs"] <- merge1[,"thurstone_tam"] - merge1[,"thurstone_mirt"]
-    ind <- which(abs(merge1[,"diff_est"]) < 0.01)
-
-    # tam vs. mirt
-    test_that("tf1", {
-       expect_true(all(abs(merge1[ind,"diff_thurs"]) < 0.02) )
-    })
 
     # tam vs. conquest
     itC <- itemFromRes(resC)
@@ -45,13 +52,65 @@ if(isTRUE(file.exists(cf))){
     merge2[,"diff_est"] <- merge2[,"est_tam"] - merge2[,"est_conquest"]
     merge2[,"diff_thurs"] <- merge2[,"thurstone_tam"] - merge2[,"thurstone_conquest"]
 
-    # tam vs. conquest
-    test_that("tf2", {
-    expect_true(all(abs(merge2[,"diff_thurs"]) < 0.05) )
+    # ConQuest is optional on developer machines. If available, the threshold
+    # extraction should remain in the same range as the TAM output.
+    test_that("PCM Thurstonian thresholds are comparable for TAM and ConQuest", {
+       expect_all_abs_lt(merge2[,"diff_thurs"], tolerance = 0.05)
     })
 }
 
-# to do: jetzt noch fuer 2pl
+test_that("GPCM Thurstonian thresholds and BISTA item parameters are comparable for TAM and mirt", {
+   data(data.gpcm, package = "TAM")
+   gpcmDat <- data.frame(pid = seq_len(nrow(data.gpcm)), data.gpcm)
+
+   # TAM uses TAM::tam.threshold(prob.lvl = .625) for both PCM and GPCM. The
+   # mirt path solves the same cumulative GPCM probability directly in eatModel.
+   defTG <- suppressWarnings(defineModel(dat = gpcmDat, items = -1, id = "pid", irtmodel = "GPCM",
+                                         software = "tam", n.iterations = 300, nodes = 15,
+                                         boundary = 1, remove.no.answers = FALSE, progress = FALSE,
+                                         analysis.name = "gpcm_tam", verbose = FALSE))
+   runTG <- suppressWarnings(runModel(defTG))
+   resTG <- suppressWarnings(getResults(runTG, omitPV = TRUE, omitWle = TRUE, omitFit = TRUE, omitRegr = TRUE))
+
+   irtMG <- data.frame(item = colnames(gpcmDat)[-1], irtmod = "gpcm", stringsAsFactors = FALSE)
+   defMG <- suppressWarnings(defineModel(dat = gpcmDat, items = -1, id = "pid", irtmodel = irtMG,
+                                         software = "mirt", n.iterations = 300, nodes = 15,
+                                         boundary = 1, remove.no.answers = FALSE, progress = FALSE,
+                                         analysis.name = "gpcm_mirt", verbose = FALSE))
+   runMG <- suppressWarnings(runModel(defMG))
+   resMG <- suppressWarnings(getResults(runMG, omitPV = TRUE, omitWle = TRUE, omitFit = TRUE, omitRegr = TRUE))
+
+   itTG <- itemFromRes(resTG)
+   itMG <- itemFromRes(resMG)
+   mergeG <- eatTools::mergeAttr(itTG[,c("item", "category", "estSlope", "thurstone")],
+                                 itMG[,c("item", "category", "estSlope", "thurstone")],
+                                 by = c("item", "category"), setAttr = FALSE, all = TRUE,
+                                 xName = "tam", yName = "mirt", suffixes = c("_tam", "_mirt"))
+   mergeG[,"diff_thurs"] <- mergeG[,"thurstone_tam"] - mergeG[,"thurstone_mirt"]
+
+   expect_gt(nrow(mergeG), 0)
+   expect_false(anyNA(mergeG[,c("thurstone_tam", "thurstone_mirt")]))
+   expect_all_abs_lt(mergeG[,"diff_thurs"], tolerance = 0.02)
+
+   # transformToBista() should use these Thurstonian thresholds for GPCM. With a
+   # common theta reference population, TAM and mirt should therefore produce
+   # almost identical BISTA item parameters.
+   refPop <- data.frame(domain = "Dim1", m = 0, sd = 1)
+   cuts <- list(Dim1 = list(values = c(400, 500, 600)))
+   tfTG <- suppressWarnings(transformToBista(equat1pl(resTG), refPop = refPop, cuts = cuts, vera = FALSE))
+   tfMG <- suppressWarnings(transformToBista(equat1pl(resMG), refPop = refPop, cuts = cuts, vera = FALSE))
+   bistaG <- eatTools::mergeAttr(tfTG[["itempars"]][,c("item", "category", "dimension", "estTransf625", "estTransfBista")],
+                                 tfMG[["itempars"]][,c("item", "category", "dimension", "estTransf625", "estTransfBista")],
+                                 by = c("item", "category", "dimension"), setAttr = FALSE, all = TRUE,
+                                 xName = "tam", yName = "mirt", suffixes = c("_tam", "_mirt"))
+   bistaG[,"diff_theta"] <- bistaG[,"estTransf625_tam"] - bistaG[,"estTransf625_mirt"]
+   bistaG[,"diff_bista"] <- bistaG[,"estTransfBista_tam"] - bistaG[,"estTransfBista_mirt"]
+
+   expect_gt(nrow(bistaG), 0)
+   expect_false(anyNA(bistaG[,c("estTransf625_tam", "estTransf625_mirt", "estTransfBista_tam", "estTransfBista_mirt")]))
+   expect_all_abs_lt(bistaG[,"diff_theta"], tolerance = 0.02)
+   expect_all_abs_lt(bistaG[,"diff_bista"], tolerance = 2)
+})
 
 
 

--- a/tests/testthat/test_transformToBista.r
+++ b/tests/testthat/test_transformToBista.r
@@ -85,3 +85,42 @@ tle.neu   <- suppressWarnings(transformToBista ( equatingList = L.t1t3, refPop=t
   expect_true(compareObj(tle$refPop, tle.neu$refPop, by="domain"))
 })
 
+test_that("2PL transformation to 62.5% respects software parameterization", {
+  makeEq <- function(source) {
+    items <- c("I1", "I2")
+    est <- c(-0.6, 0.8)
+    slope <- c(0.75, 1.5)
+    rows <- rbind(
+      data.frame(model = "m1", source = source, var1 = items, var2 = "Cat1", type = "fixed", indicator.group = "items", group = "Dim1", par = "est", derived.par = NA, value = est),
+      data.frame(model = "m1", source = source, var1 = items, var2 = "Cat1", type = "fixed", indicator.group = "items", group = "Dim1", par = "estSlope", derived.par = NA, value = slope),
+      # Include slope standard errors because itemFromRes() creates estSlope_se;
+      # transformToBista() must still select the actual slope column.
+      data.frame(model = "m1", source = source, var1 = items, var2 = "Cat1", type = "fixed", indicator.group = "items", group = "Dim1", par = "estSlope", derived.par = "se", value = c(0.1, 0.2)),
+      data.frame(model = "m1", source = source, var1 = c("p1", "p2"), var2 = NA, type = "fixed", indicator.group = "persons", group = "Dim1", par = "pv", derived.par = "pv1", value = c(-0.2, 0.3)),
+      data.frame(model = "m1", source = source, var1 = NA, var2 = NA, type = "tech", indicator.group = NA, group = NA, par = "ID", derived.par = "id", value = NA)
+    )
+    ret <- list(
+      items = list(m1 = list(Dim1 = list(eq = list(B.est = c(Mean.Mean = 0, Haebara = 0, Stocking.Lord = 0), descriptives = c(N.Items = 0, SD = NA, Var = NA, linkerror = NA)), items = NULL, method = "Mean.Mean"))),
+      results = rows
+    )
+    class(ret) <- c("eq2tom", "list")
+    ret
+  }
+  refPop <- data.frame(domain = "Dim1", m = 0, sd = 1)
+  cuts <- list(Dim1 = list(values = c(400, 500, 600)))
+  logit625 <- log(0.625/(1 - 0.625))
+
+  # TAM stores the 2PL difficulty in the slope-scaled logit, so the whole
+  # threshold expression has to be divided by the slope.
+  tam <- suppressWarnings(transformToBista(makeEq("tam"), refPop = refPop, cuts = cuts, vera = FALSE, idVarName = "id"))
+  expect_equal(tam$itempars$estTransf625, with(tam$itempars, (estTransf + logit625) / estSlope), tolerance = 1e-10)
+  pTam <- with(tam$itempars, plogis(estSlope * estTransf625 - estTransf))
+  expect_equal(pTam, rep(0.625, 2), tolerance = 1e-10)
+
+  # mirt stores the 2PL difficulty on the theta scale; only the .625 logit
+  # offset is divided by the slope.
+  mirt <- suppressWarnings(transformToBista(makeEq("mirt"), refPop = refPop, cuts = cuts, vera = FALSE, idVarName = "id"))
+  expect_equal(mirt$itempars$estTransf625, with(mirt$itempars, estTransf + logit625 / estSlope), tolerance = 1e-10)
+  pMirt <- with(mirt$itempars, plogis(estSlope * (estTransf625 - estTransf)))
+  expect_equal(pMirt, rep(0.625, 2), tolerance = 1e-10)
+})


### PR DESCRIPTION
Hi @weirichs Kannst du mal bitte anschauen, ich find's gut so. Sind Tests + 2 kleine Sachen im Code verbessert, denn:

1. The mirt 2PL path could still fail because itemFromRes() can produce both estSlope and estSlope_se, and transformToBista() was picking both as slope candidates.
I fixed that locally:
[R/transformToBista.R (line 94)](D:/eat/eatModel/R/transformToBista.R:94): ignores slope SE columns when selecting the slope estimate.

und dann noch eine robustere Variante nach Software zu unterscheiden bzw. mit Fallback:

2. [R/transformToBista.R (line 109)](D:/eat/eatModel/R/transformToBista.R:109): keeps the TAM/mirt formula split, with fallback to the source column if runModelAttributes$software is absent.