### PR TITLE
Fix BISTA transformation edge cases

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macos-15-intel, r: 'release'}
+          - {os: macOS-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -42,6 +42,13 @@ jobs:
           extra-packages: any::rcmdcheck
           needs: check
 
+      - name: Rebuild macOS TBB-linked dependencies
+        if: runner.os == 'macOS'
+        shell: Rscript {0}
+        run: |
+          install.packages("RcppParallel", type = "source", repos = "https://cloud.r-project.org")
+          install.packages("qs2", type = "source", repos = "https://cloud.r-project.org")
+
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest,   r: 'release'}
+          - {os: macos-15-intel, r: 'release'}
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
@@ -59,7 +59,7 @@ jobs:
 
           rcheck_dirs <- list.dirs(".", recursive = TRUE, full.names = TRUE)
           rcheck_dirs <- rcheck_dirs[grepl("\\.Rcheck$", rcheck_dirs)]
-          files <- file.path(rcheck_dirs, "00check.log")
+          files <- file.path(rcheck_dirs, c("00check.log", "00install.out"))
           test_dirs <- file.path(rcheck_dirs, "tests")
           files <- c(files, unlist(lapply(test_dirs, list.files,
             pattern = "\\.Rout(\\.fail)?$", full.names = TRUE

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,23 @@
+# eatModel 0.10.32 [Aug 2026]
+
+* fix `getTrafo()` for transformation databases that store mathematics under
+  `mat` while keeping the public `subject = "math"` API
+* make `getTrafo()` robust when requested subjects do not contain all requested
+  domains and when combined anchor data frames have different columns
+* make `transformToBista()` work without competence level `cuts`; continuous
+  transformations and continuous linking errors are still returned, while VERA
+  item output is allowed without `kstufe`
+* fix duplicate plausible-value ID checks in `transformToBista()`
+* pin the macOS R CMD check job to the Intel runner because `mirt` currently
+  fails during package installation on the ARM `macos-latest` runner
+* annotate `00install.out` in failed R CMD check jobs
+* bugfix in Q matrix consistency checks
+* improve handling of missings in background variables
+* add argument `remove.insuff.pattern` in `defineModel()`
+* avoid duplicate notifications when items violate more than one model
+  requirement criterion
+* bugfix in variable renaming for ConQuest conditioning models
+
 # eatModel 0.10.22 [Jun 2026]
 
 * add tests for equivalence table in partial credit (`simEquiTable()`)

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,8 +8,8 @@
   transformations and continuous linking errors are still returned, while VERA
   item output is allowed without `kstufe`
 * fix duplicate plausible-value ID checks in `transformToBista()`
-* pin the macOS R CMD check job to the Intel runner because `mirt` currently
-  fails during package installation on the ARM `macos-latest` runner
+* rebuild `RcppParallel` and `qs2` from source in the macOS R CMD check job to
+  avoid incompatible binary TBB linkage when loading `mirt`
 * annotate `00install.out` in failed R CMD check jobs
 * bugfix in Q matrix consistency checks
 * improve handling of missings in background variables

--- a/R/getTrafo.r
+++ b/R/getTrafo.r
@@ -29,6 +29,7 @@ getTrafo <- function(dataBase = "I:/Methoden/10_sonstige Materialien/trafo.rda",
        if(length(dom3)>0) {
           ret    <- lapply(subj2, FUN = function(su) {
                     extr <- intersect(dom3, names(trafo[[mode]][[grade]][[su]][[study]]))
+                    if(length(extr) == 0) {return(NULL)}
                     if(length(extr) > 0) {
                        rp <- do.call("rbind", lapply(extr, FUN = function(e) {trafo[[mode]][[grade]][[su]][[study]][[e]][["refPop"]]}))
                        cts<- do.call("c", lapply(extr, FUN = function(e) {trafo[[mode]][[grade]][[su]][[study]][[e]][["cuts"]]}))
@@ -36,9 +37,10 @@ getTrafo <- function(dataBase = "I:/Methoden/10_sonstige Materialien/trafo.rda",
                        inf<- do.call("c", lapply(extr, FUN = function(e) {trafo[[mode]][[grade]][[su]][[study]][[e]][["info"]]}))
                     }
                     return(list(refPop=rp, cuts = cts, anchor = anc, info=inf))})
+          ret    <- ret[!vapply(ret, is.null, logical(1))]
           refPop <- do.call("rbind", lapply(ret, FUN = function(r) {r[["refPop"]]}))
           cuts   <- do.call("c", lapply(ret, FUN = function(r) {r[["cuts"]]}))
-          anchor <- do.call("rbind", lapply(ret, FUN = function(r) {r[["anchor"]]}))
+          anchor <- do.call(plyr::rbind.fill, lapply(ret, FUN = function(r) {r[["anchor"]]}))
           info   <- do.call("c", lapply(ret, FUN = function(r) {r[["info"]]}))
           return(list(anchor=anchor, refPop = refPop, cuts=cuts, info=info))
        }

--- a/R/getTrafo.r
+++ b/R/getTrafo.r
@@ -18,9 +18,11 @@ getTrafo <- function(dataBase = "I:/Methoden/10_sonstige Materialien/trafo.rda",
     study  <- match.arg(arg=study, choices=eval(formals(getTrafo)[["study"]]))
     target1<- trafo[[mode]][[grade]]
     subj1  <- names(target1)
-    mis1   <- setdiff(subject, subj1)
+    subjectTrafo <- subject
+    subjectTrafo[subject == "math" & !"math" %in% subj1 & "mat" %in% subj1] <- "mat"
+    mis1   <- subject[!subjectTrafo %in% subj1]
     if(length(mis1)>0) {message(paste0("subject(s) '",paste(mis1, collapse="', '"), "' not included in mode '",mode,"', grade '",grade,"'. These subjects will be ignored."))}
-    subj2  <- intersect(subject, subj1)
+    subj2  <- subjectTrafo[subjectTrafo %in% subj1]
     if(length(subj2) > 0 ) {
        dom1  <- unique(unlist(lapply(subj2, FUN = function(su) {names(trafo[[mode]][[grade]][[su]][[study]])})))
        dom2  <- setdiff(domain, dom1)

--- a/R/transformToBista.R
+++ b/R/transformToBista.R
@@ -47,9 +47,14 @@ transformToBista <- function(equatingList, refPop, cuts, weights = NULL,
                           wahl <- intersect(which(equatingList[["results"]][,"model"] == mod), which(equatingList[["results"]][,"group"] == dimname))
                           if(length(wahl)==0) {return(NULL)}
                           resMD<- equatingList[["results"]][unique(c(wahl,  which(equatingList[["results"]][,"type"] == "tech"))),]
+                          pvRows <- intersect(which(resMD[,"par"] == "pv"), which(resMD[,"indicator.group"] == "persons"))
+                          if(length(pvRows)>0) {
+                              pvIds <- resMD[pvRows, c("var1", "derived.par"), drop=FALSE]
+                              if(any(duplicated(pvIds))) {stop(paste( "Model '",mod,"', Dimension '",dimname,"': cases according to '", id,"' variable are not unique.\n",sep=""))}
+                          }
                           rex  <- pvFromRes(resMD, toWideFormat = TRUE, idVarName = idVarName, verbose=FALSE)
                           if (!is.null(rex)) {
-                              if(length(rex[,id]) != unique(length(rex[,id]))) {stop(paste( "Model '",mod,"', Dimension '",dimname,"': cases according to '", id,"' variable are not unique.\n",sep=""))}
+                              if(length(rex[,id]) != length(unique(rex[,id]))) {stop(paste( "Model '",mod,"', Dimension '",dimname,"': cases according to '", id,"' variable are not unique.\n",sep=""))}
                           }
     ### check: keine verankerten parameter?
                           offSet  <- grep("offset", as.character(resMD[,"par"]))
@@ -151,7 +156,7 @@ transformToBista <- function(equatingList, refPop, cuts, weights = NULL,
                                 equ <- equatingList[["items"]][[mod]][[dimname]][["eq"]][["B.est"]][[ equatingList[["items"]][[mod]][[dimname]][["method"]] ]]
                                 if(isPCM) {if(equ != 0) {stop("For partial credit models, the equating constant must be zero, i.e. you have to calibrate the focus population with anchored parameters before calling equat1pl().")}}
     ### Hotfix fuer bayesianisch
-                                if (!exists("mat")) { mat <- refPop[match(dimname,  refPop[,"domain"]),] }
+                                if (!exists("mat", inherits = FALSE)) { mat <- refPop[match(dimname,  refPop[,"domain"]),] }
                                 pv[,"valueTransfBista"] <- (pv[,"value"] + equ - mat[,3]) / mat[,4] * mat[,6] + mat[,5]
     ### Dazu muss zuerst Mittelwert und SD der Fokuspopulation bestimmt werden.
                                 if (!is.null(pv)) {
@@ -196,23 +201,28 @@ transformToBista <- function(equatingList, refPop, cuts, weights = NULL,
                                     itFrame <- itFrame |> dplyr::mutate(refMean= mat[,3], refSD = mat[,4], refTransfMean=mat[,5], refTransfSD= mat[,6])
                                 }
     ### 2. Transformation der Personenparameter: kann auch dann stattfinden, wenn PVs bayesianisch gezogen wurden
-                                if(!exists("mat1") ) {mat1 <- match(dimname, names(cuts)); stopifnot(length(mat1)==1)}
+                                if(isFALSE(cutsMis) && !exists("mat1", inherits = FALSE)) {mat1 <- match(dimname, names(cuts)); stopifnot(length(mat1)==1)}
                                 if (!is.null(pv)) {
                                     if ( isFALSE(cutsMis) ) { pv[,"traitLevel"]   <- eatTools::num.to.cat(x = pv[,"valueTransfBista"], cut.points = cuts[[mat1]][["values"]], cat.values = cuts[[mat1]][["labels"]])}
                                     pv[,"dimension"]  <- pv[,"group"]
-                                    if(!exists("le")) {
-                                        warning("Skip check whether all competence levels are occupied (due to bayesian plausible values imputation).")
-                                    }  else  {
-                                        chk <- unique(le[,"traitLevel"]) %in% unique(pv[,"traitLevel"])
-                                        if ( length( which(chk == FALSE)) > 0) {
-                                             warning(paste("Model '",unique(itFrame[,"model"]),"', dimension '",unique(itFrame[,"dimension"]),"': No plausible values on trait level(s) '",paste( unique(le[,"traitLevel"])[which(chk == FALSE)], collapse = "', '"), "'.", sep=""))
+                                    if ( isFALSE(cutsMis) && !isPCM && !is.null ( equatingList[["items"]]) ) {
+                                        if(!exists("le", inherits = FALSE)) {
+                                            warning("Skip check whether all competence levels are occupied (due to bayesian plausible values imputation).")
+                                        }  else  {
+                                            chk <- unique(le[,"traitLevel"]) %in% unique(pv[,"traitLevel"])
+                                            if ( length( which(chk == FALSE)) > 0) {
+                                                 warning(paste("Model '",unique(itFrame[,"model"]),"', dimension '",unique(itFrame[,"dimension"]),"': No plausible values on trait level(s) '",paste( unique(le[,"traitLevel"])[which(chk == FALSE)], collapse = "', '"), "'.", sep=""))
+                                            }
                                         }
-                                        stopifnot ( length( unique ( na.omit(itFrame[,"linkingErrorTransfBista"]))) %in% 0:1)
+                                    }
+                                    if(!isPCM && !is.null ( equatingList[["items"]]) && !is.null(itFrame) && "linkingErrorTransfBista" %in% colnames(itFrame)) {
+                                        leTransf <- unique(na.omit(itFrame[,"linkingErrorTransfBista"]))
+                                        stopifnot ( length(leTransf) %in% 0:1)
                                         pv[,"linkingError"] <- equatingList[["items"]][[mod]][[dimname]][["eq"]][["descriptives"]][["linkerror"]]
-                                        pv[,"linkingErrorTransfBista"] <- unique ( itFrame[,"linkingErrorTransfBista"])
+                                        pv[,"linkingErrorTransfBista"] <- if(length(leTransf)==0) {NA_real_} else {leTransf}
                                     }
                                     ori <- colnames(pv)                             ### nur wenn untere Bedingung == TRUE, gibt es das Objekt 'le', das gemergt werden soll
-                                    if ( cutsMis == FALSE && !is.null ( equatingList[["items"]]) && exists("le") ) {
+                                    if ( cutsMis == FALSE && !is.null ( equatingList[["items"]]) && exists("le", inherits = FALSE) ) {
                                          pv  <- eatTools::mergeAttr ( pv, le, by = "traitLevel", sort = FALSE, all.x = TRUE, all.y = FALSE, setAttr = FALSE, unitName = "trait levels", xName = "plausible values", yName = "linking error list", verbose = c("match"))
                                          pv  <- pv[,c(ori, "linkingErrorTraitLevel")]
                                     }

--- a/R/transformToBista_help.R
+++ b/R/transformToBista_help.R
@@ -12,8 +12,24 @@ adaptEatRepVersion <- function ( x ) {
 ### ----------------------------------------------------------------------------
 
 createLinkingErrorObject <- function (itempars, years) {
+  if (is.null(itempars) || nrow(itempars) == 0 || !"dimension" %in% colnames(itempars)) {
+    return(NULL)
+  }
+  depVars <- character()
+  if ("linkingError" %in% colnames(itempars)) {
+    depVars <- c(depVars, "value")
+  }
+  if ("linkingErrorTransfBista" %in% colnames(itempars)) {
+    depVars <- c(depVars, "valueTransfBista")
+  }
+  if (all(c("traitLevel", "linkingErrorTraitLevel") %in% colnames(itempars))) {
+    depVars <- c(depVars, "traitLevel")
+  }
+  if (length(depVars) == 0) {
+    return(NULL)
+  }
   res <- do.call("rbind", by(data = itempars, INDICES = itempars[,"dimension"], FUN = function (d) {
-    r1 <- do.call("rbind", lapply(c("value", "valueTransfBista", "traitLevel"), FUN = function (av) {
+    r1 <- do.call("rbind", lapply(depVars, FUN = function (av) {
       if ( av %in% c("value", "valueTransfBista")) {
         prm <- "mean"
         le  <- unique(d[,car::recode(av, "'value'='linkingError'; 'valueTransfBista'='linkingErrorTransfBista'")])
@@ -37,7 +53,7 @@ createItemVeraObj <- function(itempars, roman, results, q3bound){
   itemVera   <- itempars[,allCols]
   colnames(itemVera) <- car::recode ( colnames(itemVera), "'dimension'='domain'; 'item'='iqbitem_id'; 'itemDiscrim'='trennschaerfe'; 'estTransf'='logit'; 'estTransfBista'='bista'; 'traitLevel'='kstufe'")
   colnames(itemVera)[match(pCols, colnames(itemVera))] <- paste0("lh", eatTools::removePattern ( string = pCols, pattern = "^itemP"))
-  if ( roman == TRUE ) {
+  if ( roman == TRUE && "kstufe" %in% colnames(itemVera) ) {
     if (!all(itemVera[,"kstufe"] %in% c("1a", "1b", 1:5))) {stop(paste("Competence levels do not match allowed values. '1a', '1b', '1', '2', '3', '4', '5' is allowed. '",paste(names(table(itemVera[,"kstufe"])), collapse = "', '"),"' was found.\n",sep=""))}
     itemVera[,"kstufe"] <- car::recode (itemVera[,"kstufe"], "'1a'='Ia'; '1b'='Ib'; '1'='I'; '2'='II'; '3'='III'; '4'='IV'; '5'='V'")
   }

--- a/tests/testthat/test_getTrafo.r
+++ b/tests/testthat/test_getTrafo.r
@@ -1,0 +1,51 @@
+makeMiniTrafo <- function() {
+  domainEntry <- function(domain, item, parameter, extra = NULL) {
+    anchor <- data.frame(item = item, parameter = parameter, stringsAsFactors = FALSE)
+    if(!is.null(extra)) {anchor[["extra"]] <- extra}
+    list(
+      refPop = data.frame(domain = domain, m = parameter, sd = 1, stringsAsFactors = FALSE),
+      cuts = stats::setNames(list(list(values = c(400, 500), labels = c("I", "II", "III"))), domain),
+      anchor = anchor,
+      info = stats::setNames(paste("info", domain), domain)
+    )
+  }
+
+  list(
+    paper = list(
+      primary = list(
+        math = list(vera = list(
+          GL = domainEntry("GL", "m1", 0),
+          MS = domainEntry("MS", "m2", 1)
+        )),
+        deu = list(vera = list(
+          lesen = domainEntry("lesen", "d1", 2, extra = "kept")
+        ))
+      )
+    )
+  )
+}
+
+test_that("getTrafo combines transformation entries across subjects and domains", {
+  out <- getTrafo(
+    dataBase = makeMiniTrafo(), mode = "paper", grade = "primary",
+    subject = c("math", "deu"), domain = "all", study = "vera"
+  )
+
+  expect_setequal(out$refPop$domain, c("GL", "MS", "lesen"))
+  expect_setequal(names(out$cuts), c("GL", "MS", "lesen"))
+  expect_equal(length(out$info), 3)
+  expect_true(all(c("item", "parameter", "extra") %in% colnames(out$anchor)))
+  expect_true(is.na(out$anchor[match("m1", out$anchor$item), "extra"]))
+  expect_equal(out$anchor[match("d1", out$anchor$item), "extra"], "kept")
+})
+
+test_that("getTrafo skips subjects without the requested domain", {
+  out <- getTrafo(
+    dataBase = makeMiniTrafo(), mode = "paper", grade = "primary",
+    subject = c("math", "deu"), domain = "GL", study = "vera"
+  )
+
+  expect_equal(out$refPop$domain, "GL")
+  expect_equal(names(out$cuts), "GL")
+  expect_equal(out$anchor$item, "m1")
+})

--- a/tests/testthat/test_getTrafo.r
+++ b/tests/testthat/test_getTrafo.r
@@ -13,7 +13,7 @@ makeMiniTrafo <- function() {
   list(
     paper = list(
       primary = list(
-        math = list(vera = list(
+        mat = list(vera = list(
           GL = domainEntry("GL", "m1", 0),
           MS = domainEntry("MS", "m2", 1)
         )),

--- a/tests/testthat/test_thurstone_thresholds.R
+++ b/tests/testthat/test_thurstone_thresholds.R
@@ -100,6 +100,8 @@ test_that("GPCM Thurstonian thresholds and BISTA item parameters are comparable 
    cuts <- list(Dim1 = list(values = c(400, 500, 600)))
    tfTG <- suppressWarnings(transformToBista(equat1pl(resTG), refPop = refPop, cuts = cuts, vera = FALSE))
    tfMG <- suppressWarnings(transformToBista(equat1pl(resMG), refPop = refPop, cuts = cuts, vera = FALSE))
+   expect_equal(tfTG[["itempars"]][["estTransf625"]], tfTG[["itempars"]][["thurstone"]], tolerance = 1e-10)
+   expect_equal(tfMG[["itempars"]][["estTransf625"]], tfMG[["itempars"]][["thurstone"]], tolerance = 1e-10)
    bistaG <- eatTools::mergeAttr(tfTG[["itempars"]][,c("item", "category", "dimension", "estTransf625", "estTransfBista")],
                                  tfMG[["itempars"]][,c("item", "category", "dimension", "estTransf625", "estTransfBista")],
                                  by = c("item", "category", "dimension"), setAttr = FALSE, all = TRUE,

--- a/tests/testthat/test_transformToBista.r
+++ b/tests/testthat/test_transformToBista.r
@@ -174,6 +174,22 @@ test_that("transformation works without competence level cuts", {
   expect_equal(unique(out$personpars$linkingErrorTransfBista), 20, tolerance = 1e-10)
 })
 
+test_that("no-cuts transformation keeps VERA output and continuous linking errors", {
+  refPop <- data.frame(domain = "Dim1", m = 0, sd = 1)
+  out <- suppressWarnings(transformToBista(
+    makeTiny2plEq(), refPop = refPop, roman = TRUE, years = c(2020, 2024),
+    idVarName = "id"
+  ))
+
+  expect_s3_class(out, "transfBista")
+  expect_s3_class(out$itemparsVera, "data.frame")
+  expect_false("kstufe" %in% colnames(out$itemparsVera))
+  expect_setequal(out$linkingErrors$depVar, c("value", "valueTransfBista"))
+  expect_false("traitLevel" %in% out$linkingErrors$depVar)
+  expect_equal(unique(out$linkingErrors$linkingError[out$linkingErrors$depVar == "value"]), 0.2)
+  expect_equal(unique(out$linkingErrors$linkingError[out$linkingErrors$depVar == "valueTransfBista"]), 20)
+})
+
 test_that("duplicated PV ids are rejected before reshaping", {
   refPop <- data.frame(domain = "Dim1", m = 0, sd = 1)
   cuts <- list(Dim1 = list(values = c(400, 500, 600)))

--- a/tests/testthat/test_transformToBista.r
+++ b/tests/testthat/test_transformToBista.r
@@ -8,6 +8,27 @@ compareObj <- function (obj1, obj2, by) {
          return(expect_true(all.equal(vgl.i[,1],vgl.i[,2])))})))
   return(ret)}
 
+makeTiny2plEq <- function(source = "tam", person_ids = c("p1", "p2"), pv_values = c(-0.2, 0.3)) {
+  items <- c("I1", "I2")
+  est <- c(-0.6, 0.8)
+  slope <- c(0.75, 1.5)
+  rows <- rbind(
+    data.frame(model = "m1", source = source, var1 = items, var2 = "Cat1", type = "fixed", indicator.group = "items", group = "Dim1", par = "est", derived.par = NA, value = est),
+    data.frame(model = "m1", source = source, var1 = items, var2 = "Cat1", type = "fixed", indicator.group = "items", group = "Dim1", par = "estSlope", derived.par = NA, value = slope),
+    # Include slope standard errors because itemFromRes() creates estSlope_se;
+    # transformToBista() must still select the actual slope column.
+    data.frame(model = "m1", source = source, var1 = items, var2 = "Cat1", type = "fixed", indicator.group = "items", group = "Dim1", par = "estSlope", derived.par = "se", value = c(0.1, 0.2)),
+    data.frame(model = "m1", source = source, var1 = person_ids, var2 = NA, type = "fixed", indicator.group = "persons", group = "Dim1", par = "pv", derived.par = "pv1", value = pv_values),
+    data.frame(model = "m1", source = source, var1 = NA, var2 = NA, type = "tech", indicator.group = NA, group = NA, par = "ID", derived.par = "id", value = NA)
+  )
+  ret <- list(
+    items = list(m1 = list(Dim1 = list(eq = list(B.est = c(Mean.Mean = 0, Haebara = 0, Stocking.Lord = 0), descriptives = c(N.Items = 0, SD = NA, Var = NA, linkerror = 0.2)), items = NULL, method = "Mean.Mean"))),
+    results = rows
+  )
+  class(ret) <- c("eq2tom", "list")
+  ret
+}
+
 # load(pl2w("c:/diskdrv/Winword/Psycho/IQB/Dropbox/R/eat/eatModel/tests/testthat/tf_example1.rda"))
 load(test_path("tf_example1.rda"))
 
@@ -18,6 +39,33 @@ test_that("tf1", {
   expect_true(all.equal(tf2b$linkingErrors , tf2b.neu$linkingErrors))
   expect_true(compareObj(tf2b$means,tf2b.neu$means, by = c("model", "domain")))
   expect_true(compareObj(tf2b$refPop , tf2b.neu$refPop , by="domain"))
+})
+
+test_that("BISTA transformation follows the documented linear formulas", {
+  tf2b.neu <- suppressWarnings(transformToBista(equatingList = eq2b, refPop = ref, cuts = cuts, vera = FALSE))
+  ip <- tf2b.neu$itempars
+  expect_equal(
+    ip$estTransfBista,
+    (ip$estTransf625 - ip$refMean) / ip$refSD * ip$refTransfSD + ip$refTransfMean,
+    tolerance = 1e-10
+  )
+  expect_equal(
+    ip$linkingErrorTransfBista,
+    sqrt((ip$linkingError^2) * (ip$refTransfSD^2) / (ip$refSD^2)),
+    tolerance = 1e-10
+  )
+
+  pp <- tf2b.neu$personpars
+  info <- unique(ip[,c("model", "dimension", "linkingConstant", "refMean", "refSD", "refTransfMean", "refTransfSD", "linkingErrorTransfBista")])
+  colnames(info)[match("linkingErrorTransfBista", colnames(info))] <- "itemLinkingErrorTransfBista"
+  pp <- merge(pp, info, by = c("model", "dimension"), all.x = TRUE, all.y = FALSE, sort = FALSE)
+  expect_false(anyNA(pp$refMean))
+  expect_equal(
+    pp$valueTransfBista,
+    (pp$value + pp$linkingConstant - pp$refMean) / pp$refSD * pp$refTransfSD + pp$refTransfMean,
+    tolerance = 1e-10
+  )
+  expect_equal(pp$linkingErrorTransfBista, pp$itemLinkingErrorTransfBista, tolerance = 1e-10)
 })
 
 # load(pl2w("c:/diskdrv/Winword/Psycho/IQB/Dropbox/R/eat/eatModel/tests/testthat/tf_example2.rda"))
@@ -86,41 +134,52 @@ tle.neu   <- suppressWarnings(transformToBista ( equatingList = L.t1t3, refPop=t
 })
 
 test_that("2PL transformation to 62.5% respects software parameterization", {
-  makeEq <- function(source) {
-    items <- c("I1", "I2")
-    est <- c(-0.6, 0.8)
-    slope <- c(0.75, 1.5)
-    rows <- rbind(
-      data.frame(model = "m1", source = source, var1 = items, var2 = "Cat1", type = "fixed", indicator.group = "items", group = "Dim1", par = "est", derived.par = NA, value = est),
-      data.frame(model = "m1", source = source, var1 = items, var2 = "Cat1", type = "fixed", indicator.group = "items", group = "Dim1", par = "estSlope", derived.par = NA, value = slope),
-      # Include slope standard errors because itemFromRes() creates estSlope_se;
-      # transformToBista() must still select the actual slope column.
-      data.frame(model = "m1", source = source, var1 = items, var2 = "Cat1", type = "fixed", indicator.group = "items", group = "Dim1", par = "estSlope", derived.par = "se", value = c(0.1, 0.2)),
-      data.frame(model = "m1", source = source, var1 = c("p1", "p2"), var2 = NA, type = "fixed", indicator.group = "persons", group = "Dim1", par = "pv", derived.par = "pv1", value = c(-0.2, 0.3)),
-      data.frame(model = "m1", source = source, var1 = NA, var2 = NA, type = "tech", indicator.group = NA, group = NA, par = "ID", derived.par = "id", value = NA)
-    )
-    ret <- list(
-      items = list(m1 = list(Dim1 = list(eq = list(B.est = c(Mean.Mean = 0, Haebara = 0, Stocking.Lord = 0), descriptives = c(N.Items = 0, SD = NA, Var = NA, linkerror = NA)), items = NULL, method = "Mean.Mean"))),
-      results = rows
-    )
-    class(ret) <- c("eq2tom", "list")
-    ret
-  }
   refPop <- data.frame(domain = "Dim1", m = 0, sd = 1)
   cuts <- list(Dim1 = list(values = c(400, 500, 600)))
   logit625 <- log(0.625/(1 - 0.625))
 
   # TAM stores the 2PL difficulty in the slope-scaled logit, so the whole
   # threshold expression has to be divided by the slope.
-  tam <- suppressWarnings(transformToBista(makeEq("tam"), refPop = refPop, cuts = cuts, vera = FALSE, idVarName = "id"))
+  tam <- suppressWarnings(transformToBista(makeTiny2plEq("tam"), refPop = refPop, cuts = cuts, vera = FALSE, idVarName = "id"))
   expect_equal(tam$itempars$estTransf625, with(tam$itempars, (estTransf + logit625) / estSlope), tolerance = 1e-10)
   pTam <- with(tam$itempars, plogis(estSlope * estTransf625 - estTransf))
   expect_equal(pTam, rep(0.625, 2), tolerance = 1e-10)
 
   # mirt stores the 2PL difficulty on the theta scale; only the .625 logit
   # offset is divided by the slope.
-  mirt <- suppressWarnings(transformToBista(makeEq("mirt"), refPop = refPop, cuts = cuts, vera = FALSE, idVarName = "id"))
+  mirt <- suppressWarnings(transformToBista(makeTiny2plEq("mirt"), refPop = refPop, cuts = cuts, vera = FALSE, idVarName = "id"))
   expect_equal(mirt$itempars$estTransf625, with(mirt$itempars, estTransf + logit625 / estSlope), tolerance = 1e-10)
   pMirt <- with(mirt$itempars, plogis(estSlope * (estTransf625 - estTransf)))
   expect_equal(pMirt, rep(0.625, 2), tolerance = 1e-10)
+})
+
+test_that("transformation works without competence level cuts", {
+  refPop <- data.frame(domain = "Dim1", m = 0, sd = 1)
+  warn <- character()
+  txt <- capture.output(out <- withCallingHandlers(
+    transformToBista(makeTiny2plEq(), refPop = refPop, vera = FALSE, idVarName = "id"),
+    warning = function(w) {
+      warn <<- c(warn, conditionMessage(w))
+      invokeRestart("muffleWarning")
+    }
+  ))
+
+  expect_s3_class(out, "transfBista")
+  expect_false(any(grepl("Skip check whether all competence levels", warn, fixed = TRUE)))
+  expect_false("traitLevel" %in% colnames(out$itempars))
+  expect_false("traitLevel" %in% colnames(out$personpars))
+  expect_equal(out$itempars$estTransfBista, out$itempars$estTransf625 * 100 + 500, tolerance = 1e-10)
+  expect_equal(out$personpars$valueTransfBista, out$personpars$value * 100 + 500, tolerance = 1e-10)
+  expect_equal(unique(out$itempars$linkingErrorTransfBista), 20, tolerance = 1e-10)
+  expect_equal(unique(out$personpars$linkingErrorTransfBista), 20, tolerance = 1e-10)
+})
+
+test_that("duplicated PV ids are rejected before reshaping", {
+  refPop <- data.frame(domain = "Dim1", m = 0, sd = 1)
+  cuts <- list(Dim1 = list(values = c(400, 500, 600)))
+
+  expect_error(
+    suppressWarnings(transformToBista(makeTiny2plEq(person_ids = c("p1", "p1")), refPop = refPop, cuts = cuts, vera = FALSE, idVarName = "id")),
+    "cases according to 'id' variable are not unique"
+  )
 })


### PR DESCRIPTION
## Summary

This PR fixes several edge cases in `getTrafo()` and `transformToBista()` that came up while reviewing and testing the transformation workflow.

No sensitive transformation data were read or included in this PR. In particular, neither the real `trafo.rda` nor the real Excel transformation rules file were loaded or committed or read or evaluated by any AI. The added tests use synthetic/minimal fixtures only.

## Motivation

During github testing, a few fragile paths became visible:

- `transformToBista()` was partly written to allow missing `cuts`, but still accessed `cuts` later and failed.
- The duplicate PV-ID check was ineffective.
- `getTrafo()` could run into undefined intermediate objects when requested subject/domain combinations had no matching entries.
- Combining anchor data frames with heterogeneous columns could fail or drop structure.

## Changes

- `transformToBista()`
  - Makes the no-`cuts` path work as intended.
  - Runs competence-level checks only when `cuts` are available.
  - Keeps continuous linking-error information on the BISTA metric for person parameters.
  - Detects duplicated PV IDs before reshaping.
  - Makes local `exists()` checks safer by using `inherits = FALSE`.

- `getTrafo()`
  - Skips subjects that do not contain any requested domains.
  - Uses `plyr::rbind.fill` when combining anchor frames across entries.

- Tests
  - Adds synthetic `getTrafo()` tests for multi-subject/domain retrieval and skipped nonmatching subjects.
  - Adds `transformToBista()` tests for:
    - transformation without `cuts`,
    - duplicated PV IDs,
    - documented linear BISTA transformation formulas,
    - existing 2PL TAM/mirt parameterization behavior.

## Validation

Targeted tests pass:

```r
pkgload::load_all(".")
testthat::test_file("tests/testthat/test_getTrafo.r")
testthat::test_file("tests/testthat/test_transformToBista.r")